### PR TITLE
DCA cleanup for Contao 5 / fix toggle icon

### DIFF
--- a/src/Resources/contao/dca/tl_map.php
+++ b/src/Resources/contao/dca/tl_map.php
@@ -42,51 +42,6 @@ $GLOBALS['TL_DCA']['tl_map'] = array
 			'fields'                  => array('id','title'),
 			'format'                  => '[%s] - %s'
 		),
-		
-		'global_operations' => array
-		(
-			'all' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['MSC']['all'],
-				'href'                => 'act=select',
-				'class'               => 'header_edit_all',
-				'attributes'          => 'onclick="Backend.getScrollOffset()" accesskey="e"'
-			)
-		),
-		'operations' => array
-		(
-			'edit' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['tl_map']['edit'],
-				'href'                => 'table=tl_map_points',
-				'icon'                => 'edit.svg'
-			),
-			'editheader' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['tl_map']['editheader'],
-				'href'                => 'act=edit',
-				'icon'                => 'header.svg'
-			),
-			'copy' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['tl_map']['copy'],
-				'href'                => 'act=copy',
-				'icon'                => 'copy.svg'
-			),
-			'delete' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['tl_map']['delete'],
-				'href'                => 'act=delete',
-				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
-			),
-			'show' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['tl_map']['show'],
-				'href'                => 'act=show',
-				'icon'                => 'show.svg'
-			)
-		)
 	),
 
 
@@ -184,7 +139,6 @@ $GLOBALS['TL_DCA']['tl_map'] = array
 			'eval'                    => array( 'tl_class'=>'w50','rgxp'=>'natural'),
 			'sql'                     => "int(10) NOT NULL default '19'"
 		)
-
 	)
 );
 

--- a/src/Resources/contao/dca/tl_map_points.php
+++ b/src/Resources/contao/dca/tl_map_points.php
@@ -114,7 +114,7 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 		'published' => array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_map_points']['toggle'],
-            'toggle'                  => true,
+			'toggle'                  => true,
 			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('submitOnChange'=>true, 'doNotCopy'=>true, 'tl_class'=>'w50'),

--- a/src/Resources/contao/dca/tl_map_points.php
+++ b/src/Resources/contao/dca/tl_map_points.php
@@ -46,19 +46,6 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 			'fields'                  => array('title'),
 			'format'                  => '%s'
 		),
-
-		'global_operations' => array
-		(
-			'all' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['MSC']['all'],
-				'href'                => 'act=select',
-				'class'               => 'header_edit_all',
-				'attributes'          => 'onclick="Backend.getScrollOffset()" accesskey="e"'
-			)
-		),
-
-		'operations' => array()
 	),
 
 	// Palettes

--- a/src/Resources/contao/dca/tl_map_points.php
+++ b/src/Resources/contao/dca/tl_map_points.php
@@ -57,18 +57,8 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 				'attributes'          => 'onclick="Backend.getScrollOffset()" accesskey="e"'
 			)
 		),
-		
-		'operations' => array
-		(
 
-			'toggle' => array
-			(
-				'label'               => &$GLOBALS['TL_LANG']['tl_map_points']['toggle'],
-				'icon'                => 'visible.svg',
-				'href'                => 'act=toggle&amp;field=published',
-				'button_callback'     => array('tl_map_points', 'toggleIcon')
-			)
-		)
+		'operations' => array()
 	),
 
 	// Palettes
@@ -137,6 +127,7 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 		'published' => array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_map_points']['toggle'],
+            'toggle'                  => true,
 			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('submitOnChange'=>true, 'doNotCopy'=>true, 'tl_class'=>'w50'),
@@ -144,22 +135,3 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 		)
 	)
 );
-
-
-
-class tl_map_points extends Backend{
-
-	public function toggleIcon($row, $href, $label, $title, $icon, $attributes)
-	{
-	
-		$href .= '&amp;id=' . $row['id'];
-
-		if (!$row['published'])
-		{
-			$icon = 'invisible.svg';
-		}
-
-      	return '<a href="' . $this->addToUrl($href) . '" title="' . StringUtil::specialchars($title) . '" data-title="' . StringUtil::specialchars($title) . '" data-title-disabled="' . StringUtil::specialchars($title) . '" data-action="contao--scroll-offset#store" onclick="return AjaxRequest.toggleField(this,true)">' . Image::getHtml($icon, $label, 'data-icon="visible.svg" data-icon-disabled="invisible.svg" data-state="' . ($row['published'] ? 1 : 0) . '"') . '</a> ';
-	}
-}
-


### PR DESCRIPTION
### Description

This PR just cleans up the dca and fixes the toggle operation not working after c9414b1de4c925c67f0c565f7b7cf56644d4fa84

**Since Contao 4.13**
We can now use "toggle" => true to have the same published behavior and don't need custom logic 208dc102f79176b857770461a4ff8bfd5daaf243
https://docs.contao.org/dev/reference/dca/list/#toggle-operation

**Since Contao 5.3**
We can also completely remove the operations since they are the defaults that are set by Contao itself df21bb1a2be429e97ce6dc3d798514488e88e810
6302411ac07c5c6ecfcad23b70226d8bda3e0616
https://docs.contao.org/dev/reference/dca/list/#global-operations
https://docs.contao.org/dev/reference/dca/list/#global-operations

This will also adjust the icons to be Contao 5.3 AND 5.4 ready
![image](https://github.com/user-attachments/assets/41e72a47-1ae3-4b65-9382-481362f551c9)
![image](https://github.com/user-attachments/assets/c978b79d-85f9-4983-8f38-4dbfe32526c3)

I'll let you and [wernerjoss](https://github.com/wernerjoss) handle the rest for the contao 5 compatibility but you are close 😄 