### PR TITLE
Road to Contao 5 compat - Part 2

### DIFF
--- a/src/Resources/contao/classes/MapViewer.php
+++ b/src/Resources/contao/classes/MapViewer.php
@@ -2,12 +2,9 @@
 
 use Contao\ContentElement;
 use Contao\BackendTemplate;
-use Contao\StringUtil; 
 use Contao\System;
 use Contao\FilesModel;
 use Contao\File;
-use Symfony\Component\HttpFoundation\Request;
-
 use Map\Model\MapModel;
 use Map\Model\MapPointsModel;
 
@@ -15,28 +12,28 @@ class MapViewer extends ContentElement
 {
 	protected $strTemplate = 'ce_mapviewer';
 
-	public function generate()
+	public function generate(): string
 	{
-		if (System::getContainer()->get('contao.routing.scope_matcher')
-			->isBackendRequest(System::getContainer()->get('request_stack')->getCurrentRequest() ?? Request::create(''))
-		)  
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objMap = MapModel::findByPK($this->map);
 			$objTemplate = new BackendTemplate('be_wildcard');
-			$objTemplate->wildcard = '### ' . strtoupper($GLOBALS['TL_LANG']['tl_content']['map_legend']) . ' ###';
+			$objTemplate->wildcard = '### ' . $GLOBALS['TL_LANG']['tl_content']['map_legend'] . ' ###';
 			$objTemplate->title = '['. $objMap->id.'] - '. $objMap->title;
-			return $objTemplate->parse();	
+
+			return $objTemplate->parse();
 		}
+
 		return parent::generate();
-	}//end generate
+	}
 
-	protected function compile()
+	protected function compile(): void
 	{
-
 		$GLOBALS['TL_JAVASCRIPT'][] = 'bundles/jonnyspmap/leaflet.js';
 		$GLOBALS['TL_CSS'][] = 		  'bundles/jonnyspmap/leaflet.css';
 
-		global $objPage;
 		$this->loadLanguageFile('tl_map');
 		$this->loadLanguageFile('tl_map_points');
 
@@ -73,12 +70,12 @@ class MapViewer extends ContentElement
 		$filter = array('column' => array('pid=?','published=?'),'value' => array($objMap->id,1));
 		$objPoints = MapPointsModel::findAll($filter);
 
-		$points = array();	
+		$points = array();
 
-		if (isset($objPoints) && count($objPoints) > 0){
-
-			foreach ($objPoints as $key => $value) {
-
+		if (null !== $objPoints)
+		{
+			foreach ($objPoints as $key => $value)
+			{
 				try
 				{
 					$position = unserialize($value->position);
@@ -118,14 +115,9 @@ class MapViewer extends ContentElement
 						"info" => boolval($value->info)
 					);
 				}
-
-				
 			}
-
 		}
-		
-	$this->Template->Points = $points;
 
-	}//end compile
-
-}//end class
+		$this->Template->Points = $points;
+	}
+}

--- a/src/Resources/contao/dca/tl_map.php
+++ b/src/Resources/contao/dca/tl_map.php
@@ -20,7 +20,7 @@ $GLOBALS['TL_DCA']['tl_map'] = array
 			(
 				'id' => 'primary'
 			)
-		)	
+		)
 	),
 
 

--- a/src/Resources/contao/dca/tl_map_points.php
+++ b/src/Resources/contao/dca/tl_map_points.php
@@ -82,8 +82,7 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_map_points']['image'],
 			'inputType'               => 'fileTree',
-			// 'eval'                    => array('fieldType'=>'radio', 'files'=>true, 'filesOnly'=>true, 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes']),
-		    'eval'                    => array('fieldType'=>'radio', 'files'=>true, 'filesOnly'=>true, 'extensions'=>['jpg','jpeg','png']),
+			'eval'                    => array('fieldType'=>'radio', 'files'=>true, 'filesOnly'=>true, 'extensions'=>'%contao.image.valid_extensions%'),
 			'sql'                     => ['type' => 'binary','notnull' => false,'length' => 16,'fixed' => true]
 		),
 		'description' => array

--- a/src/Resources/contao/dca/tl_map_points.php
+++ b/src/Resources/contao/dca/tl_map_points.php
@@ -31,8 +31,9 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 	(
 		'sorting' => array
 		(
-			'mode'                    => DataContainer::MODE_SORTED,
+			'mode'                    => DataContainer::MODE_PARENT,
 			'fields'                  => array('title'),
+			'headerFields'            => array('title', 'tstamp'),
 			'flag'                    => DataContainer::SORT_INITIAL_LETTER_ASC,
 			'panelLayout'             => 'filter;search,limit',
 			'defaultSearchField'      => 'title'
@@ -113,7 +114,7 @@ $GLOBALS['TL_DCA']['tl_map_points'] = array
 			'toggle'                  => true,
 			'filter'                  => true,
 			'inputType'               => 'checkbox',
-			'eval'                    => array('submitOnChange'=>true, 'doNotCopy'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('submitOnChange'=>true, 'doNotCopy'=>true, 'tl_class'=>'w50 m12'),
 			'sql'                     => array('type' => 'boolean', 'default' => false)
 		)
 	)

--- a/src/Resources/contao/templates/ce_mapviewer.html5
+++ b/src/Resources/contao/templates/ce_mapviewer.html5
@@ -15,11 +15,11 @@
 	var points_<?= $this->id; ?> = <?= json_encode($this->Points) ?>;
     var map_<?= $this->id; ?>;
 
-    var default_zoom_<?= $this->id; ?> = <?= $this->Map['zoom'] ?>;
-    var default_pos_<?= $this->id; ?> = [<?= $this->Map['latitude'] ?>, <?= $this->Map['longitude'] ?>];
-    var min_zoom_<?= $this->id; ?> = <?= $this->Map['minzoom'] ?>;
-    var max_zoom_<?= $this->id; ?> = <?= $this->Map['maxzoom'] ?>;
-    var markers_<?= $this->id; ?> = new Array();
+    var default_zoom_<?= $this->id; ?> = <?= $this->Map['zoom'] ?: 0 ?>;
+    var default_pos_<?= $this->id; ?> = [<?= $this->Map['latitude'] ?: 0 ?>, <?= $this->Map['longitude'] ?: 0 ?>];
+    var min_zoom_<?= $this->id; ?> = <?= $this->Map['minzoom'] ?: 0 ?>;
+    var max_zoom_<?= $this->id; ?> = <?= $this->Map['maxzoom'] ?: 0 ?>;
+    var markers_<?= $this->id; ?> = [];
 
     var LeafIcon = L.Icon.extend({});
 
@@ -54,7 +54,7 @@
         //map_<?= $this->id; ?>.attributionControl.setPrefix('<?= $this->Map['copyright'] ?>');
 
         $(points_<?= $this->id; ?>).each(function(index, value) {
-            
+
             if (value.image){
 
                     var cicon = new LeafIcon({
@@ -62,8 +62,8 @@
                                     iconSize: [value.size[0], value.size[1]],
                                     iconAnchor: [value.size[0]/2, value.size[1]/2],
                                     popupAnchor:  [0, value.size[1]/3 * -1 ]
-                                }); 
-        
+                                });
+
 
                     if( value.info == true){
                         markers_<?= $this->id; ?>.push(L.marker([value.latitude, value.longitude], {zoom: value.zoom, icon: cicon }).on('click', MarkerClick_<?= $this->id; ?>).bindPopup(value.description).addTo(map_<?= $this->id; ?>))
@@ -98,6 +98,6 @@
 
 </script>
 
-<?php 
+<?php
 //$this->showTemplateVars();
 ?>

--- a/src/Resources/contao/widgets/PositionSelectorField.php
+++ b/src/Resources/contao/widgets/PositionSelectorField.php
@@ -6,11 +6,11 @@ class PositionSelectorField extends Widget
 {
 
 	protected $strTemplate = 'be_widget';
-	protected $blnSubmitInput = true;	
+	protected $blnSubmitInput = true;
 
 	public function generate()
 	{
-		
+
 		$GLOBALS['TL_JAVASCRIPT'][] = 'bundles/jonnyspmap/leaflet.js';
 		$GLOBALS['TL_CSS'][] = 		  'bundles/jonnyspmap/leaflet.css';
 
@@ -19,19 +19,19 @@ class PositionSelectorField extends Widget
 		echo  '<div class="tl_text" id="'.$olmapname .'_canvas" style="width:auto; height:300px;"></div>
 
 				<script type="text/javascript">
-					
+
 					var '.$olmapname.'default_zoom = 3;
 					var '.$olmapname.'min_zoom = 1;
 					var '.$olmapname.'max_zoom = 19;
 					var '.$olmapname.'marker = {};
-					var '.$olmapname.'markerpos = ['.(isset($this->varValue[0]) ? $this->varValue[0] : 0).' ,'.(isset($this->varValue[1]) ? $this->varValue[1] : 0).'];
-					var '.$olmapname.'markerzoom = '.(isset($this->varValue[2]) ? $this->varValue[2] : 5).';
+					var '.$olmapname.'markerpos = ['.($this->varValue[0] ?: 0).' ,'.($this->varValue[1] ?: 0).'];
+					var '.$olmapname.'markerzoom = '.($this->varValue[2] ?: 5).';
 
 					var markerIcon = L.icon({
 					    iconUrl: "bundles/jonnyspmap/images/marker-icon.png",
-					    iconSize:     [25,41], 
-					    iconAnchor:   [12, 41], 
-					    popupAnchor:  [1, -30] 
+					    iconSize:     [25,41],
+					    iconAnchor:   [12, 41],
+					    popupAnchor:  [1, -30]
 					});
 
 					function onZoomed(e){
@@ -75,7 +75,7 @@ class PositionSelectorField extends Widget
 
 					window.addEvent("domready", function() {
 						'.$olmapname.'initialize();
-					});					
+					});
 
 			</script>';
 


### PR DESCRIPTION
### Description

This is a quick PR with explanations to fix a few issues - See my explanations as part of a potential "guide" ;)

#### Copying / Moving was not possible

The current child_table had another sorting mode that would not display the clipboard - this has been changed to `MODE_PARENT` to allow copying
0e1e099fc50dddc6df7ec6c0486fac9de2d3da2c

See sorting modes for more information :)
https://docs.contao.org/dev/reference/dca/list/

#### Valid image extensions

We can use `%contao.image.valid_extensions%` nowadays :)
a5fc171b253213fb07b32e2559577327468c3494

#### Mapviewer and default values

As per https://github.com/jonnysp/Map/issues/1#issuecomment-2523401464, I've slightly changed some stuff in the DCA for better readability and removed unnecessary code: a8d78ea813d938e582979a83e8854522d0caf2f0

However @wernerjoss is completely right and you can simply check if it's not null since any collection result will always be of at least count 1 ;)

The problem was simply, that the map points did exist and were set, however as an empty string!
When parsing the template, the empty string `''` would not be output at all, thus leading to JavaScript errors.

I fixed that here by using the coalescing operator `?:` in short syntax (It's the same as `!empty($this->Map['zoom']) ? $this->Map['zoom'] : '0'`)
b988ce6db3c94616f16bc6e36dff6e241c63ac0c
4511373d7c88e435fb130c4f6f67b0cc8b4685ef

I'm pretty sure that it would now work with Contao 5, however, we could do some code cleanup which would be another followup PR