### PR TITLE
Handle missing PHP 8 warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{php,twig,yaml,yml}]
+indent_style = tab
+indent_size = 4
+
+[*.json]
+indent_size = 4
+
+[*.{html5,svg,min.css,min.js}]
+insert_final_newline = false
+
+[*.html5]
+indent_style = space
+indent_size = 2

--- a/src/Resources/contao/classes/MapViewer.php
+++ b/src/Resources/contao/classes/MapViewer.php
@@ -42,12 +42,16 @@ class MapViewer extends ContentElement
 
 		try
 		{
-			$mapposition = unserialize($objMap->position);
+			$mapPosition = unserialize($objMap->position);
 		}
 		catch (Exception $e)
 		{
-			$mapposition = array();
+			$mapPosition = array();
 		}
+
+		$lat = isset($mapPosition[0]) && '' !== $mapPosition[0] ? $mapPosition[0] : 0;
+		$lng = isset($mapPosition[1]) && '' !== $mapPosition[1] ? $mapPosition[1] : 0;
+		$zoom = isset($mapPosition[2]) && '' !== $mapPosition[2] ? $mapPosition[2] : 5;
 
 		$Map = array(
 			"id" => $objMap->id,
@@ -56,9 +60,9 @@ class MapViewer extends ContentElement
 			"title" => $objMap->title,
 			"description" => $objMap->description,
 			"height" => $objMap->height,
-			"latitude" => $mapposition[0],
-			"longitude"  => $mapposition[1],
-			"zoom"  => $mapposition[2],
+			"latitude" => $lat,
+			"longitude" => $lng,
+			"zoom" => $zoom,
 			"autozoom" => boolval($objMap->autozoom),
 			"mousescroll" => boolval($objMap->mousescroll),
 			"minzoom" => $objMap->minzoom,

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -18,27 +18,30 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['map'] = array
 	'sql'                     => "int(10) unsigned NOT NULL default '0'"
 );
 
-class tl_content_map extends Backend 
+class tl_content_map extends Backend
 {
-
-	public function getMap()
+	public function getMap(): array
 	{
-		$objMaps = MapModel::findAll();
 		$arrMaps = array();
-		foreach ($objMaps as $objMap)
+
+		if ($objMaps = MapModel::findAll())
 		{
-			$arrMaps[$objMap->id] = '[ID ' . $objMap->id . '] - '. $objMap->title;
+			foreach ($objMaps as $objMap)
+			{
+				$arrMaps[$objMap->id] = '[ID ' . $objMap->id . '] - '. $objMap->title;
+			}
 		}
+
 		return $arrMaps;
 	}
 
-	public function editMap(DataContainer $dc)
+	public function editMap(DataContainer $dc): string
 	{
 		$this->loadLanguageFile('tl_map');
 
 		$title = sprintf($GLOBALS['TL_LANG']['tl_map']['editheader'][1], $dc->value);
 		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'map', 'table'=>'tl_map','act'=>'edit', 'id'=>$dc->value , 'popup'=>'1', 'nb'=>'1'));
+
 		return ' <a href="' . StringUtil::specialcharsUrl($href) . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $title)) . '\',\'url\':this.href});return false">' . Image::getHtml('alias.svg', $title) . '</a>';
 	}
-
 }

--- a/src/Resources/contao/widgets/PositionSelectorField.php
+++ b/src/Resources/contao/widgets/PositionSelectorField.php
@@ -1,6 +1,6 @@
 <?php
+
 use Contao\Widget;
-use Contao\StringUtil;
 
 class PositionSelectorField extends Widget
 {
@@ -8,13 +8,16 @@ class PositionSelectorField extends Widget
 	protected $strTemplate = 'be_widget';
 	protected $blnSubmitInput = true;
 
-	public function generate()
+	public function generate(): string
 	{
-
 		$GLOBALS['TL_JAVASCRIPT'][] = 'bundles/jonnyspmap/leaflet.js';
 		$GLOBALS['TL_CSS'][] = 		  'bundles/jonnyspmap/leaflet.css';
 
 		$olmapname = 'olmap'.$this->__get('currentRecord');
+
+		$lat = isset($this->varValue[0]) && '' !== $this->varValue[0] ? $this->varValue[0] : 0;
+		$lng = isset($this->varValue[1]) && '' !== $this->varValue[1] ? $this->varValue[1] : 0;
+		$zoom = isset($this->varValue[2]) && '' !== $this->varValue[2] ? $this->varValue[2] : 5;
 
 		echo  '<div class="tl_text" id="'.$olmapname .'_canvas" style="width:auto; height:300px;"></div>
 
@@ -24,8 +27,8 @@ class PositionSelectorField extends Widget
 					var '.$olmapname.'min_zoom = 1;
 					var '.$olmapname.'max_zoom = 19;
 					var '.$olmapname.'marker = {};
-					var '.$olmapname.'markerpos = ['.($this->varValue[0] ?: 0).' ,'.($this->varValue[1] ?: 0).'];
-					var '.$olmapname.'markerzoom = '.($this->varValue[2] ?: 5).';
+					var '.$olmapname.'markerpos = ['.$lat.' ,'.$lng.'];
+					var '.$olmapname.'markerzoom = '.$zoom.';
 
 					var markerIcon = L.icon({
 					    iconUrl: "bundles/jonnyspmap/images/marker-icon.png",


### PR DESCRIPTION
### Description

Final PR for this to handle most if not all PHP8 warnings

I also added an editorconfig to match your coding style since you are using tab indentation as well
* 060ece6c4f6bdd67b38af17d226c1356c2e64a39

#### Null warning on the map content element selection with no maps created

Can only ever show a title for a selection if a map exists (gotta get used to it in PHP 8, especially since you'll be coding strict types in the future -> A warning in PHP 8 is an error in PHP9)

* ee2abd3e97976de06e207983030ef2c2a360be9f

#### Map positioning 

Kinda not strict enough that I did in the latest PR. We actually want to properly check if it either isset and then do the check for the empty string, I also am using `$lat`, `$lng` and `$zoom` for better readability, should be self-explanatory.

* f09c2486c7497c19ccefc5139c452352a8574d48

#### Yet other PHP 8 warnings

The content element itself will throw a warning in the content element overview if no map exists, this should handle the case by properly checking if Map existed beforehand in the generate and compile functions.

I am also using StringUtil::deserialize with the force array parameter instead of the try / catch unserialize - There is no need to handle the exceptions here, we can let Contao do it for us.

* aa25eb2b08575309dfdf56a1fa4043a9a73de8b7